### PR TITLE
✨ Feat: 대시보드 카드와 Todo의 상태 동기화/대시 보드의 카드를 클릭하면 쿼리스트링을 이용한 라우트 이동/해당하는 …

### DIFF
--- a/src/components/todo/TodoDashboard.jsx
+++ b/src/components/todo/TodoDashboard.jsx
@@ -1,43 +1,53 @@
-import { TodoContext } from "@/context/TodoContext"; // Named Import 사용
+import { TodoContext } from "@/context/TodoContext";
 import { ClipboardCheck, Ellipsis, Monitor, Video } from "lucide-react";
 import { useContext } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 
 const TodoDashboard = () => {
-  const { todos } = useContext(TodoContext);
+  const { todos, completedTodos, pendingTodos } = useContext(TodoContext);
 
-  const all = todos.length;
-  const completed = todos.filter((todo) => todo.completed).length; // 완료된 할 일 수 계산
-  const pending = todos.filter((todo) => !todo.completed).length; // 미완료된 할 일 수 계산
+  const [searchParams] = useSearchParams();
+  const filter = searchParams.get("filter");
 
   return (
     <DashboardSection>
       <DashboardCardList>
-        <DashboardCard $flex="2" color="red">
+        <DashboardCard $flex="2" color="red" to={"/"} $highlight={!filter}>
           <div>
             <ClipboardCheck />
             <Ellipsis />
           </div>
           <p>
-            {all} <br /> All Task
+            {todos.length} <br /> All Task
           </p>
         </DashboardCard>
-        <DashboardCard $flex="1" color="blue">
+        <DashboardCard
+          $flex="1"
+          color="blue"
+          to={"?filter=completed"}
+          $highlight={filter === "completed"}
+        >
           <div>
             <Monitor />
             <Ellipsis />
           </div>
           <p>
-            {completed} <br /> Completed
+            {completedTodos.length} <br /> Completed
           </p>
         </DashboardCard>
-        <DashboardCard $flex="1" color="orange">
+        <DashboardCard
+          $flex="1"
+          color="orange"
+          to={"?filter=pending"}
+          $highlight={filter === "pending"}
+        >
           <div>
             <Video />
             <Ellipsis />
           </div>
           <p>
-            {pending} <br /> Pending
+            {pendingTodos.length} <br /> Pending
           </p>
         </DashboardCard>
       </DashboardCardList>
@@ -57,8 +67,8 @@ const DashboardCardList = styled.div`
   gap: 1rem;
   width: 100%;
 `;
-const DashboardCard = styled.div`
-  background-color: ${(props) => props.color};
+const DashboardCard = styled(Link)`
+  background-color: ${({ color }) => color};
   padding: 1rem;
   border-radius: 1rem;
   height: calc((728px / 4));
@@ -67,10 +77,8 @@ const DashboardCard = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  flex: ${(props) => props.$flex};
-
-  /* &:first-child {
-    flex-basis: 60%; */
+  flex: ${({ $flex }) => $flex};
+  text-decoration: ${({ $highlight }) => ($highlight ? "underline" : "none")};
   div {
     display: flex;
     flex-direction: row;

--- a/src/components/todo/TodoList.jsx
+++ b/src/components/todo/TodoList.jsx
@@ -2,9 +2,24 @@ import { useContext } from "react";
 import TodoItem from "./TodoItem";
 import styled from "styled-components";
 import { TodoContext } from "../../context/TodoContext"; // Named Import 사용
+import { useSearchParams } from "react-router-dom";
 
 const TodoList = () => {
-  const { todos } = useContext(TodoContext);
+  const { todos, completedTodos, pendingTodos } = useContext(TodoContext);
+
+  const [searchParams] = useSearchParams();
+
+  const getFilteredTodos = () => {
+    const filter = searchParams.get("filter");
+    if (filter === "completed") {
+      return completedTodos;
+    } else if (filter === "pending") {
+      return pendingTodos;
+    }
+    return todos;
+  };
+
+  const filteredTodos = getFilteredTodos();
 
   return (
     <TaskSection>
@@ -12,7 +27,7 @@ const TodoList = () => {
         <h1>Tasks</h1>
       </TaskHeader>
       <TaskList>
-        {todos.map((todo) => (
+        {filteredTodos.map((todo) => (
           <TodoItem key={todo.id} todo={todo} />
         ))}
       </TaskList>

--- a/src/context/TodoContext.jsx
+++ b/src/context/TodoContext.jsx
@@ -1,8 +1,9 @@
 import { createContext } from "react";
 
-// named export로 변경
 export const TodoContext = createContext({
   todos: [],
   toggleCompleted: () => {},
   handleDelete: () => {},
+  completedTodos: () => {},
+  pendingTodos: () => {},
 });

--- a/src/context/TodoProvider.jsx
+++ b/src/context/TodoProvider.jsx
@@ -21,9 +21,20 @@ export const TodoProvider = ({ children }) => {
     setTodos((prevTodos) => prevTodos.filter((todo) => todo.id !== id));
   };
 
+  const completedTodos = todos.filter((todo) => todo.completed);
+
+  const pendingTodos = todos.filter((todo) => !todo.completed);
+
   return (
     <TodoContext.Provider
-      value={{ todos, addTodos, toggleCompleted, handleDelete }} // todos 포함
+      value={{
+        todos,
+        addTodos,
+        toggleCompleted,
+        handleDelete,
+        completedTodos,
+        pendingTodos,
+      }} // todos 포함
     >
       {children}
     </TodoContext.Provider>


### PR DESCRIPTION
## 1. 대시보드 카드와 Todo의 상태 동기화

## 2. 대시 보드의 카드를 클릭하면 쿼리스트링을 이용한 라우트 이동

## 3. 해당하는 쿼리스트링을 가져와서 화면 투두 리스트 필터링

## 4. 대시 보드 카드 하이라이팅

<img width="792" alt="스크린샷 2024-09-06 오후 8 00 09" src="https://github.com/user-attachments/assets/82c24ac8-2e1f-44b9-9bc3-38803e303566">
